### PR TITLE
Remove id from resource creation and stringify Ckan logs

### DIFF
--- a/src/harvesters/ckan.ts
+++ b/src/harvesters/ckan.ts
@@ -28,8 +28,7 @@ class CkanHarvester<SourceDatasetT extends CkanPackage = CkanPackage> extends Ba
       resources: (pkg.resources || []).map((r: any) => ({
         name: r.name,
         url: r.url,
-        format: r.format,
-        ...(r.id ? { id: r.id } : {}),
+        format: r.format
       })),
 
       language: pkg.language || "EN",

--- a/src/lib/portaljs-cloud.ts
+++ b/src/lib/portaljs-cloud.ts
@@ -59,10 +59,10 @@ export async function upsertDataset({
       try {
         return await updateDataset(dataset);
       } catch (updateError) {
-        throw updateError
+        throw JSON.stringify(updateError)
       }
     } else {
-      throw creationError
+      throw JSON.stringify(creationError)
     }
   }
 }

--- a/src/lib/portaljs-cloud.ts
+++ b/src/lib/portaljs-cloud.ts
@@ -2,6 +2,7 @@ import * as Ckan from "./ckan";
 import { env } from "../../config";
 import { PortalJsCloudDataset } from "@/schemas/portaljs-cloud";
 import { CkanRequestError } from "@portaljs/ckan-api-client-js";
+import { serializeError } from "./utils";
 
 const portalConfig = {
   ckanUrl: env.PORTALJS_CLOUD_API_URL,
@@ -59,10 +60,18 @@ export async function upsertDataset({
       try {
         return await updateDataset(dataset);
       } catch (updateError) {
-        throw JSON.stringify(updateError)
+        console.error(
+          `CKAN update dataset failed: ${dataset.name}`,
+          serializeError(updateError)
+        );
+        throw updateError;
       }
     } else {
-      throw JSON.stringify(creationError)
+      console.error(
+        `CKAN create dataset failed: ${dataset.name}`,
+        serializeError(creationError)
+      );
+      throw creationError;
     }
   }
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -30,3 +30,15 @@ export const capitalize = (str: string) =>
 
 export const buildOrFq = (key: string, values: string[]) =>
   `${key}:(${values.join(" OR ")})`;
+
+export function serializeError(e: unknown): string {
+  if (e instanceof Error) {
+    const { name, message, stack, ...rest } = e as any;
+    try {
+      return JSON.stringify({ name, message, stack, ...rest });
+    } catch {
+      return `${name}: ${message}`;
+    }
+  }
+  try { return JSON.stringify(e); } catch { return String(e); }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resource listings now show only name, URL, and format for consistency (IDs removed).
  * Improved dataset operation logging with clearer, serialized error details when create/update operations fail, aiding troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->